### PR TITLE
consumer should be able to set dropdown button and split button button t...

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -3018,7 +3018,7 @@ EOD;
         }
         $icon = TbArray::popValue('icon', $htmlOptions);
         $iconOptions = TbArray::popValue('iconOptions', $htmlOptions, array());
-        if (strpos($type, 'input') === false) {
+        if (!is_array($type) && strpos($type, 'input') === false) {
             if (!empty($icon)) {
                 $label = self::icon($icon, $iconOptions) . ' ' . $label;
             }
@@ -3050,11 +3050,16 @@ EOD;
             self::addCssClass('dropup', $groupOptions);
         }
         $output = self::openTag('div', $groupOptions);
+        $toggleButtonType = TbArray::popValue('type', $htmlOptions, self::BUTTON_TYPE_HTML);
+        $toggleButtonType = is_array($toggleButtonType) ? $toggleButtonType[1] : $toggleButtonType;
         if (TbArray::popValue('split', $htmlOptions, false)) {
             $output .= self::createButton($type, $label, $htmlOptions);
-            $output .= self::dropdownToggleButton('', $htmlOptions);
+            $label = '';
+        }        
+        if(in_array($toggleButtonType, array(self::BUTTON_TYPE_LINKBUTTON, self::BUTTON_TYPE_LINK))){
+            $output .= self::dropdownToggleLink($label, $htmlOptions);       
         } else {
-            $output .= self::dropdownToggleLink($label, $htmlOptions);
+            $output .= self::dropdownToggleButton($label, $htmlOptions);
         }
         $output .= self::dropdown($items, $menuOptions);
         $output .= '</div>';
@@ -3438,7 +3443,8 @@ EOD;
     public static function buttonDropdown($label, $items, $htmlOptions = array())
     {
         $htmlOptions['items'] = $items;
-        $type = TbArray::popValue('type', $htmlOptions, self::BUTTON_TYPE_LINKBUTTON);
+        $type = isset($htmlOptions['type']) ? $htmlOptions['type'] : self::BUTTON_TYPE_SUBMIT;
+        $type = is_array($type) ? $type[0] : $type;
         return self::btn($type, $label, $htmlOptions);
     }
 

--- a/tests/unit/TbHtmlTest.php
+++ b/tests/unit/TbHtmlTest.php
@@ -2637,8 +2637,8 @@ class TbHtmlTest extends TbTestCase
         foreach ($group->children() as $i => $btnElement) {
             $btn = $I->createNode($btnElement);
             if ($i === 1) {
-                $I->seeNodeChildren($btn, array('a.dropdown-toggle', 'ul.dropdown-menu'));
-                $a = $btn->filter('a.dropdown-toggle');
+                $I->seeNodeChildren($btn, array('button.dropdown-toggle', 'ul.dropdown-menu'));
+                $a = $btn->filter('button.dropdown-toggle');
                 $I->seeNodeCssClass($a, 'btn-inverse');
                 $I->seeNodeText($a, 'Middle');
             } else {
@@ -2685,8 +2685,8 @@ class TbHtmlTest extends TbTestCase
         foreach ($group->children() as $i => $btnElement) {
             $btn = $I->createNode($btnElement);
             if ($i === 1) {
-                $I->seeNodeChildren($btn, array('a.dropdown-toggle', 'ul.dropdown-menu'));
-                $a = $btn->filter('a.dropdown-toggle');
+                $I->seeNodeChildren($btn, array('button.dropdown-toggle', 'ul.dropdown-menu'));
+                $a = $btn->filter('button.dropdown-toggle');
                 $I->seeNodeCssClass($a, 'btn-inverse');
                 $I->seeNodeText($a, 'Middle');
             } else {
@@ -2779,7 +2779,7 @@ class TbHtmlTest extends TbTestCase
         $this->assertEquals('', $html);
     }
 
-    public function testButtonDropdown()
+    public function testButtonDropdownHtmlButton()
     {
         $I = $this->codeGuy;
 
@@ -2804,6 +2804,71 @@ class TbHtmlTest extends TbTestCase
                 'dropup' => true,
                 'groupOptions' => array('class' => 'group'),
                 'menuOptions' => array('class' => 'menu'),
+            )
+        );
+        $group = $I->createNode($html, 'div.btn-group');
+        $I->seeNodeCssClass($group, 'dropup group');
+        $I->seeNodeChildren($group, array('button.dropdown-toggle', 'ul.dropdown-menu'));
+        $a = $group->filter('button.dropdown-toggle');
+        $I->seeNodeCssClass($a, 'link');
+        $I->seeNodeAttributes(
+            $a,
+            array(
+                'data-toggle' => 'dropdown'
+            )
+        );
+        $I->seeNodePattern($a, '/Action </');
+        $b = $a->filter('b.caret');
+        $I->seeNodeEmpty($b);
+        $ul = $group->filter('ul.dropdown-menu');
+        foreach ($ul->children() as $i => $liElement) {
+            $li = $I->createNode($liElement);
+            if ($i === 3) {
+                $I->seeNodeCssClass($li, 'divider');
+            } else {
+                $a = $li->filter('a');
+                if ($i === 0) {
+                    $I->seeNodeCssClass($li, 'item');
+                    $I->seeNodeCssClass($a, 'link');
+                }
+                $I->seeNodeAttributes(
+                    $a,
+                    array(
+                        'href' => '#',
+                        'tabindex' => '-1',
+                    )
+                );
+                $I->seeNodeText($a, $items[$i]['label']);
+            }
+        }
+    }
+
+    public function testButtonDropdownLinkButton()
+    {
+        $I = $this->codeGuy;
+
+        $items = array(
+            array(
+                'label' => 'Action',
+                'url' => '#',
+                'class' => 'item',
+                'linkOptions' => array('class' => 'link'),
+            ),
+            array('label' => 'Another action', 'url' => '#'),
+            array('label' => 'Something else here', 'url' => '#'),
+            TbHtml::menuDivider(),
+            array('label' => 'Separate link', 'url' => '#'),
+        );
+
+        $html = TbHtml::buttonDropdown(
+            'Action',
+            $items,
+            array(
+                'class' => 'link',
+                'dropup' => true,
+                'groupOptions' => array('class' => 'group'),
+                'menuOptions' => array('class' => 'menu'),
+                'type'=>TbHtml::BUTTON_TYPE_LINK
             )
         );
         $group = $I->createNode($html, 'div.btn-group');
@@ -2844,7 +2909,7 @@ class TbHtmlTest extends TbTestCase
         }
     }
 
-    public function testSplitButtonDropdown()
+    public function testSplitButtonDropdownHtmlButtons()
     {
         $I = $this->codeGuy;
 
@@ -2858,7 +2923,35 @@ class TbHtmlTest extends TbTestCase
 
         $html = TbHtml::splitButtonDropdown('Action',  $items);
         $group = $I->createNode($html, 'div.btn-group');
-        $I->seeNodeChildren($group, array('a.btn', 'button.dropdown-toggle', 'ul.dropdown-menu'));
+        $I->seeNodeChildren($group, array('button.btn', 'button.dropdown-toggle', 'ul.dropdown-menu'));
+        CHtml::$count = 0;
+    }
+
+    public function testSplitButtonDropdownLinkButtons()
+    {
+        $I = $this->codeGuy;
+
+        $items = array(
+            array('label' => 'Action', 'url' => '#'),
+            array('label' => 'Another action', 'url' => '#'),
+            array('label' => 'Something else here', 'url' => '#'),
+            TbHtml::menuDivider(),
+            array('label' => 'Separate link', 'url' => '#'),
+        );
+
+        $html = TbHtml::splitButtonDropdown('Action',  $items, array(
+                'type'=>array(TbHtml::BUTTON_TYPE_LINKBUTTON, TbHtml::BUTTON_TYPE_LINK)
+            )
+        );
+        $group = $I->createNode($html, 'div.btn-group');
+        $I->seeNodeChildren($group, array('a.btn', 'a.dropdown-toggle', 'ul.dropdown-menu'));
+        $a = $group->filter('a.btn');
+        $I->seeNodeAttributes(
+            $a,
+            array(
+                'href' => '#'
+            )
+        );
         CHtml::$count = 0;
     }
 


### PR DESCRIPTION
Button type set by the consumer are not honored for dropdown menus ( buttonDropdown() & splitButtonDropdown() ), but should be as both link buttons and HTML buttons are valid inside these button groups in Bootstrap 2 & 3.  Also changed to default as HTML buttons rather than link buttons to more closely align with Bootstrap's baseline samples.  Fundamentally, these changes could be applied to the /master branch as well.