### PR TITLE
Reverted attributes placeholders in activeTextInputField

### DIFF
--- a/helpers/TbHtml.php
+++ b/helpers/TbHtml.php
@@ -2651,6 +2651,15 @@ EOD;
 
         $htmlOptions = self::normalizeInputOptions($htmlOptions);
         self::addCssClass('form-control', $htmlOptions);
+        
+        $attributesLabel = $model->attributeLabels();
+        $placeHolder = \TbArray::popValue('placeholder', $htmlOptions, null);
+
+        if ($placeHolder !== null) {
+            $htmlOptions['placeholder'] = $placeHolder;
+        } else if ($placeHolder !== false) {
+            $htmlOptions['placeholder'] = isset($attributesLabel[$attribute]) ? $attributesLabel[$attribute] : '';
+        }
 
         $addOnClass = self::getAddOnClasses($htmlOptions);
         $addOnOptions = TbArray::popValue('addOnOptions', $htmlOptions, array());


### PR DESCRIPTION
Previously used the old version bootstrap (YiiBooster, DrMabuse bootstrap 3).
And all of them are displayed by default placeholders.
After the upgrade project to use yiistrap all forms have empty placeholders.

May be solution is - add the setting to enable or disable this feature, for backward compatibility...