### PR TITLE
bs3: Add apigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ If you are not using Composer, then you need to add the following to your applic
 Documentation not updated yet, but use the current docs as a guideline:
 [http://www.getyiistrap.com](http://www.getyiistrap.com)
 
+Use the following command to generate ApiGen documentation:
+
+```
+php vendor\bin\apigen generate
+```
+
 ___Note: When you use a widget, prepend a ```\``` to the filename to use autoload it through Composer:___
 
 ```php

--- a/apigen.neon
+++ b/apigen.neon
@@ -1,0 +1,70 @@
+source:
+    - .
+
+destination: api
+
+
+# list of scanned file extensions (e.g. php5, phpt...)
+extensions: [php]
+
+# directories and files matching this file mask will not be parsed
+exclude:
+    - /assets/*
+    - /api/*
+    - /gii/*
+    - /tests/*
+    - /vendor/*
+
+# similar to above, but this files will be included in class tree
+skipDocPath:
+
+# character set of source files; if you use only one across your files, we recommend you name it
+charset: [UTF-8]
+
+# elements with this name prefix will be considered as the "main project" (the rest will be considered as libraries)
+main:
+
+# title of generated documentation
+title:
+
+# base url used for sitemap (useful for public doc)
+baseUrl:
+
+# custom search engine id, will be used by search box
+googleCseId:
+
+# Google Analytics tracking code
+googleAnalytics:
+
+# choose ApiGen template theme
+templateTheme: bootstrap
+
+# want to use individual templates, higher priority than option templateTheme
+templateConfig:
+
+# the way elements are grouped in menu
+groups: auto # also: namespace, packages, none; auto will detect namespace first, than packages
+
+# access levels of included method and properties
+accessLevels: [public, protected] # also [private]
+
+# include elements marked as @internal/{@internal}
+internal: false
+
+# generate documentation for PHP internal classes
+php: true
+
+# generate highlighted source code for elements
+sourceCode: true
+
+# generate tree view of classes, interfaces, traits and exceptions
+tree: true
+
+# generate documentation for deprecated elements
+deprecated: false
+
+# generate list of tasks with @todo annotation
+todo: false
+
+# add link to ZIP archive of documentation
+download: false

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "codeception/codeception": "@stable",
         "crisu83/yii-composer": ">=1.0.0",
-        "yiisoft/yii": ">=1.1.13"
+        "yiisoft/yii": ">=1.1.13",
+        "apigen/apigen": "~4.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
I use ApiGen to generate API documentation. getyiistrap.com remains outdated, so at least this gives us something to work with. :)

The result looks like this: https://cdn.rawgit.com/marcovtwout/yiistrap/bs3-apigen-docs-generated/api/index.html